### PR TITLE
imported Factor, CholmodNotPositiveDefiniteError to address NameError

### DIFF
--- a/src/gmrf.py
+++ b/src/gmrf.py
@@ -30,6 +30,8 @@ import numpy as np
 from scipy import linalg
 from scipy.special import kv, gamma
 import scipy.sparse as sp
+from sksparse.cholmod import Factor
+from sksparse.cholmod import  CholmodNotPositiveDefiniteError
 from scipy.sparse import linalg as spla
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
The lines of code:

```python
from sksparse.cholmod import Factor
from sksparse.cholmod import  CholmodNotPositiveDefiniteError
```

were missing from `quadmesh/src/gmrf.py` leading to `NameError` when trying to execute `quadmesh/experiments/richards_equation/ex02_2d_vms_steady_advection_diffusion.py`.